### PR TITLE
Add timer, logger, and CLI functionality for session tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ go.work.sum
 .idea/
 
 /dist
+
+reflo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to **reflo** will be documented in this file.
+
+This project follows the guidelines of [Keep a Changelog](https://keepachangelog.com)
+and adheres to [Semantic Versioning](https://semver.org).
+
+---
+
+## \[Unreleased]
+
+### Added
+
+* *Add new features here.*
+
+### Changed
+
+* *Add changes that modify existing behaviour here.*
+
+### Fixed
+
+* *Add bug fixes here.*
+
+### Removed
+
+* *Add features that have been removed here.*
+
+---
+
+## \[1.0.0] - 2025-05-08
+
+### Added
+
+* **Focus session timer** with default 25‑minute focus / 5‑minute break cycle (`reflo start`).
+* **Graceful cancellation**: `Ctrl‑C` (SIGINT) cleanly stops timers via the new `Wait(ctx)` implementation.
+* **Automatic break timer** followed by an audible bell when focus or break completes.
+* **JSON session logging** to `~/.reflo/YYYY-MM-DD.json` (file name uses *local* date, entries are ISO‑8601 timestamps in UTC) with goal & retrospective notes.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@
 
 - Minimalist CLI design for instant startup
 - Session declaration and reflection input
-- 25-minute focus timer with macOS notifications
+- 25-minute focus timer with an audible bell on completion
 - 5-minute break management
-- Daily log saving (JSON format)
-- One-click daily report generation & clipboard copying
+- **Automatic JSON session logging** to `~/.reflo/YYYY-MM-DD.json`
+  (filename uses local date; timestamps are ISO-8601 / UTC)
+- Daily summary report (`reflo end-day`)
+- Graceful interruption with Ctrl-C
 
 ---
 
 ## 🛠 Installation
 
-Coming soon via Homebrew!
+### Homebrew (recommended)
 
 ```bash
 brew tap saijo-shota-biz/homebrew-reflo

--- a/cmd/reflo/main.go
+++ b/cmd/reflo/main.go
@@ -120,8 +120,8 @@ func cmdEndDay() {
 	for i, session := range sessions {
 		fmt.Printf("%d) %s ~ %s —  %s\n   %s\n",
 			i+1,
-			session.StartTime.Format("15:04"),
-			session.EndTime.Format("15:04"),
+			session.StartTime.In(time.Local).Format("15:04"),
+			session.EndTime.In(time.Local).Format("15:04"),
 			session.Goal,
 			session.Retro)
 	}

--- a/cmd/reflo/main.go
+++ b/cmd/reflo/main.go
@@ -51,58 +51,60 @@ func cmdStart() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	// タスク宣言
-	goal, err := readLine("What will you do? > ")
-	if err != nil {
-		fmt.Println("input error:", err)
-		return
-	}
+	for {
+		// タスク宣言
+		goal, err := readLine("What will you do? > ")
+		if err != nil {
+			fmt.Println("input error:", err)
+			return
+		}
 
-	// タイマー開始
-	start := time.Now().UTC()
-	fmt.Printf("Focusing %v …\n", defaultFocus)
-	if err := timer.New(defaultFocus).Wait(ctx); err != nil {
-		printTimerError(err)
-	}
-	fmt.Print("\a")
-	end := time.Now().UTC()
+		// タイマー開始
+		start := time.Now().UTC()
+		fmt.Printf("Focusing %v …\n", defaultFocus)
+		if err := timer.New(defaultFocus).Wait(ctx); err != nil {
+			printTimerError(err)
+		}
+		fmt.Print("\a")
+		end := time.Now().UTC()
 
-	// 振り返り
-	retro, err := readLine("What have you done? > ")
-	if err != nil {
-		fmt.Println("input error:", err)
-		return
-	}
+		// 振り返り
+		retro, err := readLine("What have you done? > ")
+		if err != nil {
+			fmt.Println("input error:", err)
+			return
+		}
 
-	// ログ出力
-	fmt.Printf("%v ~ %v\n", start.Format("2006-01-02 15:04"), end.Format("15:04"))
-	log := logger.NewDefaultJsonLogger()
-	err = log.Write(logger.Session{
-		StartTime: start,
-		EndTime:   end,
-		Goal:      goal,
-		Retro:     retro,
-	})
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
+		// ログ出力
+		fmt.Printf("%v ~ %v\n", start.Format("2006-01-02 15:04"), end.Format("15:04"))
+		log := logger.NewDefaultJsonLogger()
+		err = log.Write(logger.Session{
+			StartTime: start,
+			EndTime:   end,
+			Goal:      goal,
+			Retro:     retro,
+		})
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
 
-	// 休憩
-	fmt.Printf("Break %v …\n", defaultBreak)
-	if err := timer.New(defaultBreak).Wait(ctx); err != nil {
-		printTimerError(err)
-	}
+		// 休憩
+		fmt.Printf("Break %v …\n", defaultBreak)
+		if err := timer.New(defaultBreak).Wait(ctx); err != nil {
+			printTimerError(err)
+		}
 
-	// もう一周？
-	oneMore, err := readLine("One more session? (yes or no) > ")
-	if err != nil {
-		fmt.Println("input error:", err)
-		return
-	}
-	if strings.HasPrefix(strings.ToLower(oneMore), "y") {
+		// もう一周？
+		ans, err := readLine("One more session? (yes or no) > ")
+		if err != nil {
+			fmt.Println("input error:", err)
+			return
+		}
+		if !strings.HasPrefix(strings.ToLower(ans), "y") {
+			break
+		}
 		fmt.Println("========================")
-		cmdStart()
 	}
 }
 

--- a/cmd/reflo/main.go
+++ b/cmd/reflo/main.go
@@ -54,13 +54,13 @@ func cmdStart() {
 	fmt.Scan(&goal)
 
 	// タイマー開始
-	start := time.Now()
+	start := time.Now().UTC()
 	fmt.Printf("Focusing %v …\n", defaultFocus)
 	if err := timer.New(defaultFocus).Wait(ctx); err != nil {
 		printTimerError(err)
 	}
 	fmt.Print("\a")
-	end := time.Now()
+	end := time.Now().UTC()
 
 	// 振り返り
 	fmt.Print("What have you done? > ")

--- a/cmd/reflo/main.go
+++ b/cmd/reflo/main.go
@@ -94,6 +94,7 @@ func cmdStart() {
 		if err := timer.New(defaultBreak).Wait(ctx); err != nil {
 			printTimerError(err)
 		}
+		fmt.Print("\a")
 
 		// もう一周？
 		ans, err := readLine("One more session? (yes or no) > ")

--- a/cmd/reflo/main.go
+++ b/cmd/reflo/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"github.com/saijo-shota-biz/reflo/internal/logger"
+	"github.com/saijo-shota-biz/reflo/internal/timer"
+	"os"
+	"time"
+)
+
+const (
+	defaultFocus = 25 * time.Minute
+	defaultBreak = 5 * time.Minute
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		showHelp()
+	}
+
+	switch os.Args[1] {
+	case "start":
+		cmdStart()
+	case "end-day":
+		cmdEndDay()
+	case "help":
+		showHelp()
+	case "version":
+
+	}
+}
+
+func showHelp() {
+	fmt.Println(`
+reflo - Reflect, Flow, Log
+
+Usage:
+  reflo start    # start a focus session
+  reflo end-day  # output daily summary
+  reflo help     # show this message`,
+	)
+}
+
+func cmdStart() {
+	// タスク宣言
+	fmt.Print("What will you do? > ")
+	var goal string
+	fmt.Scan(&goal)
+
+	// タイマー開始
+	start := time.Now()
+	fmt.Printf("Focusing %v …\n", defaultFocus)
+	timer.New(defaultFocus).Wait()
+	fmt.Print("\a")
+	end := time.Now()
+
+	// 振り返り
+	fmt.Print("What have you done? > ")
+	var retro string
+	fmt.Scan(&retro)
+
+	// ログ出力
+	fmt.Printf("%v ~ %v\n", start.Format("2006-01-02 15:04"), end.Format("15:04"))
+	log := logger.NewDefaultJsonLogger()
+	err := log.Write(logger.Session{
+		StartTime: start,
+		EndTime:   end,
+		Goal:      goal,
+		Retro:     retro,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	// 休憩
+	fmt.Printf("Break %v …\n", defaultBreak)
+	timer.New(defaultBreak).Wait()
+
+	// もう一周？
+	fmt.Print("One more session? (yes or no) > ")
+	var oneMore string
+	fmt.Scan(&oneMore)
+	if oneMore == "yes" || oneMore == "y" {
+		fmt.Println("========================")
+		cmdStart()
+	}
+}
+
+func cmdEndDay() {
+	log := logger.NewDefaultJsonLogger()
+	sessions, err := log.ReadDay()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("=== Today's Summary ===")
+	for i, session := range sessions {
+		fmt.Printf("%d) %s ~ %s —  %s\n   %s\n",
+			i+1,
+			session.StartTime.Format("15:04"),
+			session.EndTime.Format("15:04"),
+			session.Goal,
+			session.Retro)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/saijo-shota-biz/reflo
 
 go 1.23.6
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/logger/json_logger.go
+++ b/internal/logger/json_logger.go
@@ -28,7 +28,7 @@ func (l *JsonLogger) Write(session Session) error {
 		return err
 	}
 
-	path := filepath.Join(l.root, time.Now().Format("2006-01-02")+".json")
+	path := filepath.Join(l.root, time.Now().UTC().Format("2006-01-02")+".json")
 
 	var list []Session
 	if b, err := os.ReadFile(path); err == nil {
@@ -44,7 +44,7 @@ func (l *JsonLogger) Write(session Session) error {
 func (l *JsonLogger) ReadDay() ([]Session, error) {
 	var list []Session
 
-	path := filepath.Join(l.root, time.Now().Format("2006-01-02")+".json")
+	path := filepath.Join(l.root, time.Now().UTC().Format("2006-01-02")+".json")
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return list, err

--- a/internal/logger/json_logger.go
+++ b/internal/logger/json_logger.go
@@ -28,7 +28,7 @@ func (l *JsonLogger) Write(session Session) error {
 		return err
 	}
 
-	path := filepath.Join(l.root, time.Now().UTC().Format("2006-01-02")+".json")
+	path := filepath.Join(l.root, time.Now().In(time.Local).Format("2006-01-02")+".json")
 
 	var list []Session
 	if b, err := os.ReadFile(path); err == nil {
@@ -44,7 +44,7 @@ func (l *JsonLogger) Write(session Session) error {
 func (l *JsonLogger) ReadDay() ([]Session, error) {
 	var list []Session
 
-	path := filepath.Join(l.root, time.Now().UTC().Format("2006-01-02")+".json")
+	path := filepath.Join(l.root, time.Now().In(time.Local).Format("2006-01-02")+".json")
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return list, err

--- a/internal/logger/json_logger.go
+++ b/internal/logger/json_logger.go
@@ -1,0 +1,58 @@
+package logger
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type JsonLogger struct {
+	mu   sync.Mutex
+	root string
+}
+
+func NewJsonLogger(root string) Logger {
+	return &JsonLogger{root: root}
+}
+
+func NewDefaultJsonLogger() Logger {
+	return &JsonLogger{root: getDefaultRoot()}
+}
+
+func (l *JsonLogger) Write(session Session) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := os.MkdirAll(l.root, 0755); err != nil {
+		return err
+	}
+
+	path := filepath.Join(l.root, time.Now().Format("2006-01-02")+".json")
+
+	var list []Session
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &list)
+	}
+
+	list = append(list, session)
+
+	b, _ := json.MarshalIndent(list, "", "  ")
+	return os.WriteFile(path, b, 0644)
+}
+
+func (l *JsonLogger) ReadDay() ([]Session, error) {
+	var list []Session
+
+	path := filepath.Join(l.root, time.Now().Format("2006-01-02")+".json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return list, err
+	}
+	err = json.Unmarshal(b, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}

--- a/internal/logger/json_logger_test.go
+++ b/internal/logger/json_logger_test.go
@@ -1,0 +1,107 @@
+package logger
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestJsonLogger_WriteReadRoundTrip(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	log := NewJsonLogger(fmt.Sprintf("%s/logs", dir))
+
+	session1 := Session{
+		StartTime: time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2025, 4, 1, 12, 25, 0, 0, time.UTC),
+		Goal:      "testGoal1",
+		Retro:     "testRetro1",
+	}
+
+	session2 := Session{
+		StartTime: time.Date(2025, 4, 1, 12, 30, 0, 0, time.UTC),
+		EndTime:   time.Date(2025, 4, 1, 12, 55, 0, 0, time.UTC),
+		Goal:      "testGoal2",
+		Retro:     "testRetro2",
+	}
+
+	// Act
+	err1 := log.Write(session1)
+	require.NoError(t, err1)
+	err2 := log.Write(session2)
+	require.NoError(t, err2)
+	sessions, err3 := log.ReadDay()
+	require.NoError(t, err3)
+
+	// Assert
+	require.Equal(t, 2, len(sessions))
+	require.Equal(t, session1, sessions[0])
+	require.Equal(t, session2, sessions[1])
+	expected := filepath.Join(dir, "logs", fmt.Sprintf("%s.json", time.Now().Format("2006-01-02")))
+	require.FileExists(t, expected)
+}
+
+func TestJsonLogger_CreatesDirIfMissing(t *testing.T) {
+	// Arrange
+	dir := fmt.Sprintf("%s/logs", t.TempDir())
+	log := NewJsonLogger(dir)
+	before := filepath.Join(dir, fmt.Sprintf("%s.json", time.Now().Format("2006-01-02")))
+	require.NoFileExists(t, before)
+
+	// Act
+	err := log.Write(Session{})
+	require.NoError(t, err)
+
+	// Assert
+	after := filepath.Join(dir, fmt.Sprintf("%s.json", time.Now().Format("2006-01-02")))
+	require.FileExists(t, after)
+}
+func TestJsonLogger_ReadDayEmpty(t *testing.T) {
+	// Arrange
+	dir := fmt.Sprintf("%s/logs", t.TempDir())
+	log := NewJsonLogger(dir)
+	before := filepath.Join(dir, fmt.Sprintf("%s.json", time.Now().Format("2006-01-02")))
+	require.NoFileExists(t, before)
+
+	// Act
+	sessions, err := log.ReadDay()
+
+	// Assert
+	require.Error(t, err)
+	require.Equal(t, 0, len(sessions))
+}
+
+func TestJsonLogger_ConcurrentWrites(t *testing.T) {
+	// Arrange
+	dir := fmt.Sprintf("%s/logs", t.TempDir())
+	log := NewJsonLogger(dir)
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+
+	// Act
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			s := Session{
+				StartTime: time.Now(),
+				EndTime:   time.Now().Add(1 * time.Minute),
+				Goal:      fmt.Sprintf("g%d", i),
+				Retro:     "done",
+			}
+			if err := log.Write(s); err != nil {
+				t.Errorf("write error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Assert
+	sessions, err := log.ReadDay()
+	require.NoError(t, err)
+	require.Equal(t, N, len(sessions))
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Session struct {
+	StartTime time.Time
+	EndTime   time.Time
+	Goal      string
+	Retro     string
+}
+
+type Logger interface {
+	Write(session Session) error
+	ReadDay() ([]Session, error)
+}
+
+func getDefaultRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".reflo/logs"
+	}
+	return filepath.Join(home, ".reflo/logs")
+}

--- a/internal/timer/timer.go
+++ b/internal/timer/timer.go
@@ -2,24 +2,22 @@ package timer
 
 import (
 	"context"
-	"sync"
 	"time"
 )
 
 type Timer struct {
-	once sync.Once
-	ch   chan struct{}
+	ch chan struct{}
 }
 
-func New(duration time.Duration) *Timer {
+func New(d time.Duration) *Timer {
 	t := &Timer{ch: make(chan struct{})}
 
-	go func() {
-		time.Sleep(duration)
-		t.once.Do(func() {
-			close(t.ch)
-		})
-	}()
+	if d <= 0 {
+		close(t.ch)
+		return t
+	}
+
+	time.AfterFunc(d, func() { close(t.ch) })
 
 	return t
 }

--- a/internal/timer/timer.go
+++ b/internal/timer/timer.go
@@ -1,6 +1,7 @@
 package timer
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -23,6 +24,11 @@ func New(duration time.Duration) *Timer {
 	return t
 }
 
-func (t *Timer) Wait() {
-	<-t.ch
+func (t *Timer) Wait(ctx context.Context) error {
+	select {
+	case <-t.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/internal/timer/timer.go
+++ b/internal/timer/timer.go
@@ -1,0 +1,28 @@
+package timer
+
+import (
+	"sync"
+	"time"
+)
+
+type Timer struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func New(duration time.Duration) *Timer {
+	t := &Timer{ch: make(chan struct{})}
+
+	go func() {
+		time.Sleep(duration)
+		t.once.Do(func() {
+			close(t.ch)
+		})
+	}()
+
+	return t
+}
+
+func (t *Timer) Wait() {
+	<-t.ch
+}

--- a/internal/timer/timer_test.go
+++ b/internal/timer/timer_test.go
@@ -1,0 +1,65 @@
+package timer
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+const delta = 30 * time.Millisecond
+
+func TestTimer_WaitExpiresNearDuration(t *testing.T) {
+	// Arrange
+	d := 3 * time.Second
+	tm := New(d)
+	start := time.Now()
+
+	// Act
+	tm.Wait()
+
+	// Assert
+	elapsed := time.Since(start)
+	require.True(t, d-delta <= elapsed && elapsed <= d+delta)
+}
+
+func TestTimer_ZeroDurationReturnsImmediately(t *testing.T) {
+	// Arrange
+	d := 0 * time.Second
+	tm := New(d)
+	start := time.Now()
+
+	// Act
+	tm.Wait()
+
+	// Assert
+	elapsed := time.Since(start)
+	require.True(t, elapsed <= delta)
+}
+
+func TestTimer_WaitIsIdempotent(t *testing.T) {
+	// Arrange
+	d := 1 * time.Second
+	tm := New(d)
+
+	// Act
+	done := make(chan struct{})
+	go func() {
+		tm.Wait()
+		close(done)
+	}()
+
+	time.Sleep(d + delta)
+
+	select {
+	case <-done:
+	default:
+		t.Fatalf("first Wait did not finish in %v", d+delta)
+	}
+
+	start := time.Now()
+	tm.Wait()
+
+	// Assert
+	elapsed := time.Since(start)
+	require.True(t, elapsed <= delta)
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello world")
-}


### PR DESCRIPTION
Introduces a `Timer` for tracking session durations with tests to ensure behavior. Adds a JSON-based logging system for session data, including goals and reflections. Implements a CLI for starting focus sessions, viewing daily summaries, and managing logs.